### PR TITLE
Fix build error: Update CaseStudiesSection for 2 cards only

### DIFF
--- a/src/components/CaseStudiesSection.astro
+++ b/src/components/CaseStudiesSection.astro
@@ -11,18 +11,11 @@ const { title, caseStudies } = Astro.props
   <!-- Header -->
   { title && <h2 class="bs-h2 text-center md:text-left">{ title }</h2> }
 
-  <!-- Case Study 1 -->
-  <div class="bs-mt-md">
+  <!-- Case studies -->
+  <div class="bs-mt-md grid lg:grid-cols-2 gap-8">
 
     <CardCaseStudy caseStudy={ caseStudies[0] } />
-
-  </div>
-
-  <!-- Case studies -->
-  <div class="mt-8 grid lg:grid-cols-2 gap-8">
-
     <CardCaseStudy caseStudy={ caseStudies[1] } />
-    <CardCaseStudy caseStudy={ caseStudies[2] } />
 
   </div>
 

--- a/src/components/CaseStudiesSection.es.astro
+++ b/src/components/CaseStudiesSection.es.astro
@@ -11,18 +11,11 @@ const { title, caseStudies } = Astro.props
   <!-- Header -->
   { title && <h2 class="bs-h2 text-center md:text-left">{ title }</h2> }
 
-  <!-- Case Study 1 -->
-  <div class="bs-mt-md">
+  <!-- Case studies -->
+  <div class="bs-mt-md grid lg:grid-cols-2 gap-8">
 
     <CardCaseStudy caseStudy={ caseStudies[0] } />
-
-  </div>
-
-  <!-- Case studies -->
-  <div class="mt-8 grid lg:grid-cols-2 gap-8">
-
     <CardCaseStudy caseStudy={ caseStudies[1] } />
-    <CardCaseStudy caseStudy={ caseStudies[2] } />
 
   </div>
 


### PR DESCRIPTION
The component was hardcoded to render 3 case studies (caseStudies[0], [1], [2]), but after removing Gen Scoring there are only 2. This caused the build to fail with "Cannot read properties of undefined (reading 'bg')".

https://claude.ai/code/session_01Qt1m5Rk8fB9xRqmhwRoadb